### PR TITLE
Update model data with latest 2025-2026 models

### DIFF
--- a/data/models/cohere-models.json
+++ b/data/models/cohere-models.json
@@ -393,6 +393,43 @@
         "total": 16384,
         "maxOutput": 4096
       }
+    },
+    {
+      "id": "command-a-reasoning-08-2025",
+      "name": "Command A Reasoning",
+      "creator": "cohere",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "json-out",
+        "fn-out",
+        "reason"
+      ],
+      "context": {
+        "type": "token",
+        "total": 256000,
+        "maxOutput": 32000
+      }
+    },
+    {
+      "id": "command-a-vision-07-2025",
+      "name": "Command A Vision",
+      "creator": "cohere",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 8000
+      }
     }
   ]
 }

--- a/data/models/openai-models.json
+++ b/data/models/openai-models.json
@@ -52,6 +52,7 @@
     {
       "id": "gpt-5.2",
       "extends": "gpt-5.1",
+      "releasedAt": "2025-12-11",
       "overrides": {
         "name": "GPT-5.2",
         "aliases": [
@@ -381,6 +382,43 @@
       "aliases": [
         "omni-moderation-latest"
       ]
+    },
+    {
+      "id": "sora-2",
+      "name": "Sora 2",
+      "license": "proprietary",
+      "capabilities": [
+        "txt-in",
+        "video-out"
+      ],
+      "context": {
+        "maxOutput": 1
+      },
+      "aliases": [
+        "sora-2-2025-12-08"
+      ]
+    },
+    {
+      "id": "gpt-image-1.5",
+      "name": "GPT Image 1.5",
+      "license": "proprietary",
+      "capabilities": [
+        "txt-in",
+        "img-in",
+        "img-out"
+      ],
+      "context": {
+        "maxOutput": 1,
+        "sizes": [
+          "1024x1024",
+          "1792x1024",
+          "1024x1792"
+        ],
+        "qualities": [
+          "standard",
+          "hd"
+        ]
+      }
     }
   ]
 }

--- a/data/models/qwen-models.json
+++ b/data/models/qwen-models.json
@@ -48,6 +48,18 @@
         "maxOutput": 8192
       },
       "aliases": ["qwen-3-7b", "qwen-3-7b-instruct-latest"]
+    },
+    {
+      "id": "qwen-3-max",
+      "name": "Qwen 3 Max",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 262144,
+        "maxOutput": 8192
+      },
+      "aliases": ["qwen-3-max-latest"]
     }
   ]
 }

--- a/data/models/xai-models.json
+++ b/data/models/xai-models.json
@@ -197,6 +197,19 @@
         "maxOutput": 30000
       },
       "releasedAt": "2025-11-19"
+    },
+    {
+      "id": "grok-4-1",
+      "name": "Grok 4.1",
+      "creator": "xai",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "reason", "fn-out", "json-out"],
+      "context": {
+        "type": "token",
+        "total": 256000,
+        "maxOutput": 8192
+      },
+      "releasedAt": "2025-11-17"
     }
   ]
-} 
+}


### PR DESCRIPTION
Updated model data JSON files to include the latest models released in late 2025 and early 2026, based on the repository's timeline.

Changes:
- `data/models/cohere-models.json`: Added `command-a-reasoning-08-2025` and `command-a-vision-07-2025`.
- `data/models/openai-models.json`: Added `sora-2` and `gpt-image-1.5`. Updated `gpt-5.2` with release date.
- `data/models/qwen-models.json`: Added `qwen-3-max`.
- `data/models/xai-models.json`: Added `grok-4-1`.

Validation:
- Validated JSON syntax using `jq`.
- `npm run validate:data` could not be run due to environment issues, but manual check confirms valid structure and adherence to schema conventions.

---
*PR created automatically by Jules for task [10223117088446974632](https://jules.google.com/task/10223117088446974632) started by @mitkury*