### PR TITLE
Update model data with latest 2025/2026 releases

### DIFF
--- a/data/models/google-models.json
+++ b/data/models/google-models.json
@@ -23,6 +23,23 @@
       }
     },
     {
+      "id": "gemini-3-pro-image-preview",
+      "name": "Gemini 3 Pro Image Preview",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "img-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 65536,
+        "maxOutput": 32768
+      }
+    },
+    {
       "id": "gemini-3-flash-preview",
       "name": "Gemini 3 Flash Preview",
       "license": "proprietary",

--- a/data/models/mistral-models.json
+++ b/data/models/mistral-models.json
@@ -2,6 +2,48 @@
   "creator": "mistral",
   "models": [
     {
+      "id": "mistral-large-3",
+      "name": "Mistral Large 3",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in", "json-out", "fn-out"],
+      "context": { "type": "token", "total": 131072, "maxOutput": 32768 }
+    },
+    {
+      "id": "mistral-medium-3-1",
+      "name": "Mistral Medium 3.1",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in", "json-out", "fn-out"],
+      "context": { "type": "token", "total": 131072, "maxOutput": 32768 }
+    },
+    {
+      "id": "ministral-3-14b",
+      "name": "Ministral 3 14B",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in"],
+      "context": { "type": "token", "total": 131072, "maxOutput": 32768 }
+    },
+    {
+      "id": "ministral-3-8b",
+      "name": "Ministral 3 8B",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in"],
+      "context": { "type": "token", "total": 131072, "maxOutput": 32768 }
+    },
+    {
+      "id": "ministral-3-3b",
+      "name": "Ministral 3 3B",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in"],
+      "context": { "type": "token", "total": 131072, "maxOutput": 32768 }
+    },
+    {
+      "id": "mistral-small-3-2",
+      "name": "Mistral Small 3.2",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": { "type": "token", "total": 32768, "maxOutput": 4096 }
+    },
+    {
       "id": "mistral-medium-3-2025-05-07",
       "name": "Mistral Medium 3",
       "license": "proprietary",

--- a/data/models/openai-models.json
+++ b/data/models/openai-models.json
@@ -284,6 +284,23 @@
       }
     },
     {
+      "id": "o3",
+      "name": "OpenAI o3",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "reason"
+      ],
+      "context": {
+        "type": "token",
+        "total": 200000,
+        "maxOutput": 100000
+      }
+    },
+    {
       "id": "o4-mini",
       "name": "OpenAI o4 Mini",
       "license": "proprietary",

--- a/data/models/qwen-models.json
+++ b/data/models/qwen-models.json
@@ -2,6 +2,27 @@
   "creator": "qwen",
   "models": [
     {
+      "id": "qwen-3-max-thinking",
+      "name": "Qwen 3 Max Thinking",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "reason"],
+      "context": { "type": "token", "total": 262000, "maxOutput": 65536 }
+    },
+    {
+      "id": "qwen-image-2512",
+      "name": "Qwen Image 2512",
+      "license": "apache-2.0",
+      "capabilities": ["txt-in", "img-out"],
+      "context": { "maxOutput": 1, "sizes": ["1024x1024"] }
+    },
+    {
+      "id": "qwq-32b",
+      "name": "QwQ 32B",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "reason"],
+      "context": { "type": "token", "total": 131072, "maxOutput": 32768 }
+    },
+    {
       "id": "qwen-3-235b-instruct",
       "name": "Qwen 3 235B Instruct",
       "license": "apache-2.0",


### PR DESCRIPTION
Updates the `data/models/*.json` files to include the latest AI models released in late 2025 and early 2026. This includes major releases like Gemini 3, Mistral 3, and Qwen 3 families. Confirmed model details and context windows where available.

---
*PR created automatically by Jules for task [3567508866873604411](https://jules.google.com/task/3567508866873604411) started by @mitkury*