### PR TITLE
Update model data with latest 2025/2026 releases

### DIFF
--- a/data/models/mistral-models.json
+++ b/data/models/mistral-models.json
@@ -2,6 +2,62 @@
   "creator": "mistral",
   "models": [
     {
+      "id": "mistral-large-3",
+      "name": "Mistral Large 3",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in", "json-out", "fn-out"],
+      "context": {"type": "token", "total": 262144, "maxOutput": 32768}
+    },
+    {
+      "id": "mistral-medium-3-1",
+      "name": "Mistral Medium 3.1",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in"],
+      "context": {"type": "token", "total": 131072, "maxOutput": 8192}
+    },
+    {
+      "id": "mistral-small-3-2",
+      "name": "Mistral Small 3.2",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out"],
+      "context": {"type": "token", "total": 131072, "maxOutput": 8192}
+    },
+    {
+      "id": "ministral-3-14b",
+      "name": "Ministral 3 14B",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in"],
+      "context": {"type": "token", "total": 262144, "maxOutput": 8192}
+    },
+    {
+      "id": "ministral-3-8b",
+      "name": "Ministral 3 8B",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in"],
+      "context": {"type": "token", "total": 262144, "maxOutput": 8192}
+    },
+    {
+      "id": "ministral-3-3b",
+      "name": "Ministral 3 3B",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in"],
+      "context": {"type": "token", "total": 262144, "maxOutput": 8192}
+    },
+    {
+      "id": "magistral-medium-1-2",
+      "name": "Magistral Medium 1.2",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "reason"],
+      "context": {"type": "token", "total": 131072, "maxOutput": 8192}
+    },
+    {
+      "id": "magistral-small-1-2",
+      "name": "Magistral Small 1.2",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "reason"],
+      "context": {"type": "token", "total": 131072, "maxOutput": 8192}
+    },
+    {
       "id": "mistral-medium-3-2025-05-07",
       "name": "Mistral Medium 3",
       "license": "proprietary",

--- a/data/models/openai-models.json
+++ b/data/models/openai-models.json
@@ -284,6 +284,25 @@
       }
     },
     {
+      "id": "o3",
+      "name": "OpenAI o3",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "json-out",
+        "fn-out",
+        "reason"
+      ],
+      "context": {
+        "type": "token",
+        "total": 200000,
+        "maxOutput": 100000
+      }
+    },
+    {
       "id": "o4-mini",
       "name": "OpenAI o4 Mini",
       "license": "proprietary",

--- a/data/models/qwen-models.json
+++ b/data/models/qwen-models.json
@@ -2,6 +2,28 @@
   "creator": "qwen",
   "models": [
     {
+      "id": "qwen-3-max-thinking",
+      "name": "Qwen 3 Max Thinking",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out", "reason"],
+      "context": {
+        "type": "token",
+        "total": 262144,
+        "maxOutput": 32768
+      }
+    },
+    {
+      "id": "qwq-32b",
+      "name": "QwQ 32B",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "reason"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      }
+    },
+    {
       "id": "qwen-3-235b-instruct",
       "name": "Qwen 3 235B Instruct",
       "license": "apache-2.0",

--- a/data/models/xai-models.json
+++ b/data/models/xai-models.json
@@ -197,6 +197,18 @@
         "maxOutput": 30000
       },
       "releasedAt": "2025-11-19"
+    },
+    {
+      "id": "grok-imagine",
+      "name": "Grok Imagine",
+      "creator": "xai",
+      "license": "proprietary",
+      "capabilities": ["txt-in", "video-out"],
+      "context": {
+        "maxOutput": 1,
+        "sizes": ["1024x1024"]
+      },
+      "releasedAt": "2026-01-28"
     }
   ]
 } 


### PR DESCRIPTION
Updated `data/models/*.json` files to include the latest models discovered for Mistral, OpenAI, Qwen, and xAI. Verified JSON syntax and schema compliance where possible. Added specs based on search results.

---
*PR created automatically by Jules for task [3227699451253129185](https://jules.google.com/task/3227699451253129185) started by @mitkury*