### PR TITLE
Update data with latest Google and Mistral models

### DIFF
--- a/data/models/google-models.json
+++ b/data/models/google-models.json
@@ -137,7 +137,7 @@
       }
     },
     {
-      "id": "gemini-2.0-flash",
+      "id": "gemini-2.0-flash-001",
       "name": "Gemini 2.0 Flash",
       "license": "proprietary",
       "capabilities": [
@@ -154,10 +154,13 @@
         "type": "token",
         "total": 1048576,
         "maxOutput": 8192
-      }
+      },
+      "aliases": [
+        "gemini-2.0-flash"
+      ]
     },
     {
-      "id": "gemini-2.0-flash-lite",
+      "id": "gemini-2.0-flash-lite-001",
       "name": "Gemini 2.0 Flash Lite",
       "license": "proprietary",
       "capabilities": [
@@ -174,7 +177,10 @@
         "type": "token",
         "total": 1048576,
         "maxOutput": 8192
-      }
+      },
+      "aliases": [
+        "gemini-2.0-flash-lite"
+      ]
     },
     {
       "id": "gemma-3-1b",
@@ -410,6 +416,30 @@
       }
     },
     {
+      "id": "imagen-4.0-fast-generate-001",
+      "name": "Imagen 4.0 Fast",
+      "license": "proprietary",
+      "capabilities": [
+        "txt-in",
+        "img-out"
+      ],
+      "context": {
+        "maxOutput": 4,
+        "sizes": [
+          "1024x1024",
+          "896x1280",
+          "1280x896",
+          "768x1408",
+          "1408x768",
+          "2048x2048",
+          "1792x2560",
+          "2560x1792",
+          "1536x2816",
+          "2816x1536"
+        ]
+      }
+    },
+    {
       "id": "imagen-4.0-ultra-generate-001",
       "name": "Imagen 4.0 Ultra",
       "license": "proprietary",
@@ -448,7 +478,7 @@
       }
     },
     {
-      "id": "veo-3.0-generate-preview",
+      "id": "veo-3.0-generate-001",
       "name": "Veo 3.0 Generate",
       "license": "proprietary",
       "capabilities": [
@@ -463,7 +493,37 @@
       }
     },
     {
-      "id": "veo-3.1-generate-preview",
+      "id": "veo-3.0-fast-generate-001",
+      "name": "Veo 3.0 Fast Generate",
+      "license": "proprietary",
+      "capabilities": [
+        "txt-in",
+        "img-in",
+        "video-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 480,
+        "maxOutput": 8192
+      }
+    },
+    {
+      "id": "veo-3.0-generate-preview",
+      "name": "Veo 3.0 Generate Preview",
+      "license": "proprietary",
+      "capabilities": [
+        "txt-in",
+        "img-in",
+        "video-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 480,
+        "maxOutput": 8192
+      }
+    },
+    {
+      "id": "veo-3.1-generate-001",
       "name": "Veo 3.1 Generate",
       "license": "proprietary",
       "capabilities": [
@@ -478,8 +538,38 @@
       }
     },
     {
-      "id": "veo-3.1-fast-generate-preview",
+      "id": "veo-3.1-fast-generate-001",
       "name": "Veo 3.1 Fast Generate",
+      "license": "proprietary",
+      "capabilities": [
+        "txt-in",
+        "img-in",
+        "video-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 480,
+        "maxOutput": 8192
+      }
+    },
+    {
+      "id": "veo-3.1-generate-preview",
+      "name": "Veo 3.1 Generate Preview",
+      "license": "proprietary",
+      "capabilities": [
+        "txt-in",
+        "img-in",
+        "video-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 480,
+        "maxOutput": 8192
+      }
+    },
+    {
+      "id": "veo-3.1-fast-generate-preview",
+      "name": "Veo 3.1 Fast Generate Preview",
       "license": "proprietary",
       "capabilities": [
         "txt-in",

--- a/data/models/mistral-models.json
+++ b/data/models/mistral-models.json
@@ -2,12 +2,100 @@
   "creator": "mistral",
   "models": [
     {
+      "id": "mistral-large-2512",
+      "name": "Mistral Large 3",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in", "json-out", "fn-out", "reason"],
+      "context": {"type": "token", "total": 131072, "maxOutput": 8192},
+      "aliases": ["mistral-large-3", "mistral-large-latest"]
+    },
+    {
+      "id": "mistral-large-2411",
+      "name": "Mistral Large 2.1",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in", "json-out", "fn-out"],
+      "context": {"type": "token", "total": 131072, "maxOutput": 8192},
+      "aliases": ["mistral-large-2.1"]
+    },
+    {
+      "id": "mistral-medium-2508",
+      "name": "Mistral Medium 3.1",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in", "json-out", "fn-out"],
+      "context": {"type": "token", "total": 131072, "maxOutput": 8192},
+      "aliases": ["mistral-medium-3.1"]
+    },
+    {
       "id": "mistral-medium-3-2025-05-07",
       "name": "Mistral Medium 3",
       "license": "proprietary",
       "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out", "reason"],
       "context": {"type": "token", "total": 131072, "maxOutput": 8192},
       "aliases": ["mistral-medium-3", "mistral-medium-2025"]
+    },
+    {
+      "id": "mistral-small-2506",
+      "name": "Mistral Small 3.2",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {"type": "token", "total": 32768, "maxOutput": 8192},
+      "aliases": ["mistral-small-3.2", "mistral-small-latest"]
+    },
+    {
+      "id": "ministral-3-14b-2512",
+      "name": "Ministral 3 14B",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in"],
+      "context": {"type": "token", "total": 131072, "maxOutput": 8192},
+      "aliases": ["ministral-3-14b"]
+    },
+    {
+      "id": "ministral-3-8b-2512",
+      "name": "Ministral 3 8B",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in"],
+      "context": {"type": "token", "total": 131072, "maxOutput": 8192},
+      "aliases": ["ministral-3-8b"]
+    },
+    {
+      "id": "ministral-3-3b-2512",
+      "name": "Ministral 3 3B",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in"],
+      "context": {"type": "token", "total": 131072, "maxOutput": 8192},
+      "aliases": ["ministral-3-3b"]
+    },
+    {
+      "id": "magistral-medium-2509",
+      "name": "Magistral Medium 1.2",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in", "reason", "json-out", "fn-out"],
+      "context": {"type": "token", "total": 131072, "maxOutput": 8192},
+      "aliases": ["magistral-medium-1.2"]
+    },
+    {
+      "id": "magistral-small-2509",
+      "name": "Magistral Small 1.2",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in", "reason", "json-out", "fn-out"],
+      "context": {"type": "token", "total": 32768, "maxOutput": 8192},
+      "aliases": ["magistral-small-1.2"]
+    },
+    {
+      "id": "codestral-2508",
+      "name": "Codestral",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out"],
+      "context": {"type": "token", "total": 32768, "maxOutput": 8192},
+      "aliases": ["codestral-latest"]
+    },
+    {
+      "id": "devstral-2-2512",
+      "name": "Devstral 2",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "fn-out"],
+      "context": {"type": "token", "total": 131072, "maxOutput": 8192},
+      "aliases": ["devstral-2"]
     },
     {
       "id": "mistral-large-2402",


### PR DESCRIPTION
Updated `google-models.json` and `mistral-models.json` with the latest models found in the documentation (simulated 2026 context).

**Google Updates:**
- Added `veo-3.0-generate-001`, `veo-3.0-fast-generate-001`, `veo-3.1-generate-001`, `veo-3.1-fast-generate-001`
- Added `imagen-4.0-fast-generate-001`
- Updated `gemini-2.0-flash` and `gemini-2.0-flash-lite` to use versioned IDs (`-001`) with aliases.

**Mistral Updates:**
- Added `mistral-large-2512` (Mistral Large 3)
- Added `mistral-large-2411` (Mistral Large 2.1)
- Added `mistral-medium-2508` (Mistral Medium 3.1)
- Added `mistral-small-2506` (Mistral Small 3.2)
- Added `ministral-3-14b-2512`, `ministral-3-8b-2512`, `ministral-3-3b-2512`
- Added `magistral-medium-2509`, `magistral-small-2509`
- Added `codestral-2508`
- Added `devstral-2-2512`

**Other Creators:**
- **Anthropic:** Verified that `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`, and `claude-opus-4-5-20251101` were already present in `anthropic-models.json`.
- **Cohere:** While documentation for `Command A Reasoning` etc. was found, exact API IDs could not be confirmed, so they were omitted to ensure data integrity.

Verified with `npm run validate:data` and `npm test`.

---
*PR created automatically by Jules for task [17160387090643881392](https://jules.google.com/task/17160387090643881392) started by @mitkury*