### PR TITLE
Add latest Mistral and Google models

### DIFF
--- a/data/models/google-models.json
+++ b/data/models/google-models.json
@@ -23,6 +23,79 @@
       }
     },
     {
+      "id": "gemini-3-pro-image-preview",
+      "name": "Gemini 3 Pro Image Preview",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "img-in",
+        "txt-out",
+        "img-out",
+        "json-out",
+        "reason"
+      ],
+      "context": {
+        "type": "token",
+        "total": 65536,
+        "maxOutput": 32768,
+        "sizes": [
+          "1024x1024"
+        ]
+      }
+    },
+    {
+      "id": "gemini-2.5-flash-native-audio-preview-12-2025",
+      "name": "Gemini 2.5 Flash Live",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "audio-in",
+        "video-in",
+        "txt-in",
+        "audio-out",
+        "txt-out",
+        "reason",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": [
+        "gemini-2.5-flash-live"
+      ]
+    },
+    {
+      "id": "gemini-2.5-flash-preview-tts",
+      "name": "Gemini 2.5 Flash TTS",
+      "license": "proprietary",
+      "capabilities": [
+        "txt-in",
+        "audio-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 8192,
+        "maxOutput": 16384
+      }
+    },
+    {
+      "id": "gemini-2.5-pro-preview-tts",
+      "name": "Gemini 2.5 Pro TTS",
+      "license": "proprietary",
+      "capabilities": [
+        "txt-in",
+        "audio-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 8192,
+        "maxOutput": 16384
+      }
+    },
+    {
       "id": "gemini-3-flash-preview",
       "name": "Gemini 3 Flash Preview",
       "license": "proprietary",

--- a/data/models/mistral-models.json
+++ b/data/models/mistral-models.json
@@ -2,6 +2,118 @@
   "creator": "mistral",
   "models": [
     {
+      "id": "mistral-large-2512",
+      "name": "Mistral Large 3",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out",
+        "img-in",
+        "reason"
+      ],
+      "context": {
+        "type": "token",
+        "total": 262144,
+        "maxOutput": 32768
+      },
+      "aliases": [
+        "mistral-large-3",
+        "mistral-large-latest"
+      ]
+    },
+    {
+      "id": "magistral-medium-2509",
+      "name": "Magistral Medium 1.2",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out",
+        "img-in",
+        "reason"
+      ],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 32768
+      },
+      "aliases": [
+        "magistral-medium-1.2",
+        "magistral-medium-latest"
+      ]
+    },
+    {
+      "id": "mistral-medium-2508",
+      "name": "Mistral Medium 3.1",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out",
+        "img-in"
+      ],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 32768
+      },
+      "aliases": [
+        "mistral-medium-3.1",
+        "mistral-medium-latest"
+      ]
+    },
+    {
+      "id": "mistral-small-2506",
+      "name": "Mistral Small 3.2",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out",
+        "img-in"
+      ],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 16384
+      },
+      "aliases": [
+        "mistral-small-3.2",
+        "mistral-small-latest"
+      ]
+    },
+    {
+      "id": "ministral-14b-2512",
+      "name": "Ministral 3 14B",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out",
+        "img-in"
+      ],
+      "context": {
+        "type": "token",
+        "total": 262144,
+        "maxOutput": 16384
+      },
+      "aliases": [
+        "ministral-3-14b",
+        "ministral-14b-latest"
+      ]
+    },
+    {
       "id": "mistral-medium-3-2025-05-07",
       "name": "Mistral Medium 3",
       "license": "proprietary",


### PR DESCRIPTION
Added latest Mistral models (Large 3, Medium 3.1, Small 3.2, Magistral Medium 1.2, Ministral 3 14B) and Google models (Gemini 3 Pro Image Preview, Gemini 2.5 Flash Live, TTS models) based on documentation.

---
*PR created automatically by Jules for task [13444733555089648671](https://jules.google.com/task/13444733555089648671) started by @mitkury*