### PR TITLE
Add latest models (o1, Gemini 1.5, Claude 3.5, etc.)

### DIFF
--- a/data/models/anthropic-models.json
+++ b/data/models/anthropic-models.json
@@ -163,6 +163,49 @@
         "claude-3-7-sonnet-latest",
         "claude-3-7-sonnet"
       ]
+    },
+    {
+      "id": "claude-3-5-sonnet-20241022",
+      "name": "Claude 3.5 Sonnet (New)",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 200000,
+        "maxOutput": 8192
+      },
+      "aliases": [
+        "claude-3-5-sonnet-latest",
+        "claude-3-5-sonnet"
+      ]
+    },
+    {
+      "id": "claude-3-5-haiku-20241022",
+      "name": "Claude 3.5 Haiku",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 200000,
+        "maxOutput": 8192
+      },
+      "aliases": [
+        "claude-3-5-haiku-latest",
+        "claude-3-5-haiku"
+      ]
     }
   ]
 }

--- a/data/models/google-models.json
+++ b/data/models/google-models.json
@@ -137,6 +137,26 @@
       }
     },
     {
+      "id": "gemini-2.0-pro-exp-02-05",
+      "name": "Gemini 2.0 Pro Experimental",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "audio-in",
+        "video-in",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 2097152,
+        "maxOutput": 8192
+      }
+    },
+    {
       "id": "gemini-2.0-flash",
       "name": "Gemini 2.0 Flash",
       "license": "proprietary",
@@ -155,6 +175,80 @@
         "total": 1048576,
         "maxOutput": 8192
       }
+    },
+    {
+      "id": "gemini-1.5-pro",
+      "name": "Gemini 1.5 Pro",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "audio-in",
+        "video-in",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 2097152,
+        "maxOutput": 8192
+      },
+      "aliases": [
+        "gemini-1.5-pro-latest",
+        "gemini-1.5-pro-002",
+        "gemini-1.5-pro-001"
+      ]
+    },
+    {
+      "id": "gemini-1.5-flash",
+      "name": "Gemini 1.5 Flash",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "audio-in",
+        "video-in",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 1048576,
+        "maxOutput": 8192
+      },
+      "aliases": [
+        "gemini-1.5-flash-latest",
+        "gemini-1.5-flash-002",
+        "gemini-1.5-flash-001"
+      ]
+    },
+    {
+      "id": "gemini-1.5-flash-8b",
+      "name": "Gemini 1.5 Flash-8B",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "audio-in",
+        "video-in",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 1048576,
+        "maxOutput": 8192
+      },
+      "aliases": [
+        "gemini-1.5-flash-8b-latest",
+        "gemini-1.5-flash-8b-001"
+      ]
     },
     {
       "id": "gemini-2.0-flash-lite",

--- a/data/models/meta-models.json
+++ b/data/models/meta-models.json
@@ -37,6 +37,30 @@
       }
     },
     {
+      "id": "llama-3.2-1b-instruct",
+      "name": "Llama 3.2 1B Instruct",
+      "license": "llama-3.2-community",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["llama-3.2-1b"]
+    },
+    {
+      "id": "llama-3.2-3b-instruct",
+      "name": "Llama 3.2 3B Instruct",
+      "license": "llama-3.2-community",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["llama-3.2-3b"]
+    },
+    {
       "id": "llama3-8b-8192",
       "name": "Llama 3 8B",
       "license": "llama-3-community",

--- a/data/models/mistral-models.json
+++ b/data/models/mistral-models.json
@@ -10,6 +10,81 @@
       "aliases": ["mistral-medium-3", "mistral-medium-2025"]
     },
     {
+      "id": "mistral-large-2407",
+      "name": "Mistral Large 2",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32768
+      },
+      "aliases": [
+        "mistral-large-2"
+      ]
+    },
+    {
+      "id": "pixtral-12b-2409",
+      "name": "Pixtral 12B",
+      "license": "apache-2.0",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32768
+      },
+      "aliases": [
+        "pixtral-12b"
+      ]
+    },
+    {
+      "id": "ministral-8b-latest",
+      "name": "Ministral 8B",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32768
+      }
+    },
+    {
+      "id": "ministral-3b-latest",
+      "name": "Ministral 3B",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32768
+      }
+    },
+    {
       "id": "mistral-large-2402",
       "name": "Mistral Large",
       "license": "proprietary",

--- a/data/models/openai-models.json
+++ b/data/models/openai-models.json
@@ -83,6 +83,91 @@
       ]
     },
     {
+      "id": "o1",
+      "name": "o1",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "reason",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 200000,
+        "maxOutput": 100000
+      },
+      "aliases": [
+        "o1-2024-12-17"
+      ]
+    },
+    {
+      "id": "o1-mini",
+      "name": "o1-mini",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "reason",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 65536
+      },
+      "aliases": [
+        "o1-mini-2024-09-12"
+      ]
+    },
+    {
+      "id": "o3-mini",
+      "name": "o3-mini",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "reason",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 200000,
+        "maxOutput": 100000
+      },
+      "aliases": [
+        "o3-mini-2025-01-31"
+      ]
+    },
+    {
+      "id": "gpt-4o-mini",
+      "name": "GPT-4o Mini",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 16384
+      },
+      "aliases": [
+        "gpt-4o-mini-2024-07-18"
+      ]
+    },
+    {
       "id": "gpt-5-nano",
       "name": "GPT-5 Nano",
       "license": "proprietary",

--- a/data/models/qwen-models.json
+++ b/data/models/qwen-models.json
@@ -48,6 +48,53 @@
         "maxOutput": 8192
       },
       "aliases": ["qwen-3-7b", "qwen-3-7b-instruct-latest"]
+    },
+    {
+      "id": "qwen-2.5-72b-instruct",
+      "name": "Qwen 2.5 72B Instruct",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["qwen-2.5-72b"]
+    },
+    {
+      "id": "qwen-2.5-32b-instruct",
+      "name": "Qwen 2.5 32B Instruct",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["qwen-2.5-32b"]
+    },
+    {
+      "id": "qwen-2.5-7b-instruct",
+      "name": "Qwen 2.5 7B Instruct",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["qwen-2.5-7b"]
+    },
+    {
+      "id": "qwen-2.5-coder-32b-instruct",
+      "name": "Qwen 2.5 Coder 32B Instruct",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      }
     }
   ]
 }


### PR DESCRIPTION
Added missing models for OpenAI, Google, Anthropic, Mistral, Qwen, and Meta to `data/models/`.

Added:
- OpenAI: o1, o1-mini, o3-mini, gpt-4o-mini
- Google: Gemini 1.5 Pro, Gemini 1.5 Flash, Gemini 1.5 Flash-8B, Gemini 2.0 Pro Experimental
- Anthropic: Claude 3.5 Sonnet (New), Claude 3.5 Haiku
- Mistral: Mistral Large 2, Pixtral 12B, Ministral 8B, Ministral 3B
- Qwen: Qwen 2.5 72B/32B/7B Instruct, Qwen 2.5 Coder 32B
- Meta: Llama 3.2 1B/3B Instruct

Verified JSON syntax for all modified files.

---
*PR created automatically by Jules for task [4824872777742930273](https://jules.google.com/task/4824872777742930273) started by @mitkury*