### PR TITLE
Add latest models (o1, claude-3.5, gemini-1.5, llama-3.1, deepseek-v3.2)

### DIFF
--- a/data/models/anthropic-models.json
+++ b/data/models/anthropic-models.json
@@ -163,6 +163,70 @@
         "claude-3-7-sonnet-latest",
         "claude-3-7-sonnet"
       ]
+    },
+    {
+      "id": "claude-3-5-sonnet-20241022",
+      "name": "Claude 3.5 Sonnet",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 200000,
+        "maxOutput": 8192,
+        "outputIsFixed": 1
+      },
+      "aliases": [
+        "claude-3-5-sonnet-latest",
+        "claude-3-5-sonnet"
+      ]
+    },
+    {
+      "id": "claude-3-5-haiku-20241022",
+      "name": "Claude 3.5 Haiku",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 200000,
+        "maxOutput": 8192,
+        "outputIsFixed": 1
+      },
+      "aliases": [
+        "claude-3-5-haiku-latest"
+      ]
+    },
+    {
+      "id": "claude-3-opus-20240229",
+      "name": "Claude 3 Opus",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 200000,
+        "maxOutput": 4096,
+        "outputIsFixed": 1
+      },
+      "aliases": [
+        "claude-3-opus-latest"
+      ]
     }
   ]
 }

--- a/data/models/deepseek-models.json
+++ b/data/models/deepseek-models.json
@@ -35,6 +35,47 @@
         "total": 131072,
         "maxOutput": 65536
       }
+    },
+    {
+      "id": "deepseek-v3.2",
+      "name": "DeepSeek V3.2",
+      "license": "apache-2.0",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 163840,
+        "maxOutput": 65536
+      },
+      "aliases": [
+        "deepseek-v3.2-maas"
+      ]
+    },
+    {
+      "id": "deepseek-r1-0528",
+      "name": "DeepSeek R1 (0528)",
+      "license": "apache-2.0",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out",
+        "reason"
+      ],
+      "context": {
+        "type": "token",
+        "total": 163840,
+        "maxOutput": 32768
+      },
+      "aliases": [
+        "deepseek-r1-0528-maas"
+      ]
     }
   ]
 }

--- a/data/models/google-models.json
+++ b/data/models/google-models.json
@@ -177,6 +177,77 @@
       }
     },
     {
+      "id": "gemini-1.5-pro",
+      "name": "Gemini 1.5 Pro",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "audio-in",
+        "video-in",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 2000000,
+        "maxOutput": 8192
+      },
+      "aliases": [
+        "gemini-1.5-pro-002",
+        "gemini-1.5-pro-latest"
+      ]
+    },
+    {
+      "id": "gemini-1.5-flash",
+      "name": "Gemini 1.5 Flash",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "audio-in",
+        "video-in",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 1000000,
+        "maxOutput": 8192
+      },
+      "aliases": [
+        "gemini-1.5-flash-002",
+        "gemini-1.5-flash-latest"
+      ]
+    },
+    {
+      "id": "gemini-1.5-flash-8b",
+      "name": "Gemini 1.5 Flash 8B",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "audio-in",
+        "video-in",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 1000000,
+        "maxOutput": 8192
+      },
+      "aliases": [
+        "gemini-1.5-flash-8b-latest"
+      ]
+    },
+    {
       "id": "gemma-3-1b",
       "name": "Gemma 3 1B",
       "license": "apache-2.0",

--- a/data/models/meta-models.json
+++ b/data/models/meta-models.json
@@ -163,6 +163,30 @@
         "maxOutput": 512
       },
       "aliases": ["llama-prompt-guard-2-86m"]
+    },
+    {
+      "id": "llama-3.1-405b",
+      "name": "Llama 3.1 405B",
+      "license": "llama-3-community",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 128000
+      },
+      "aliases": ["llama-3.1-405b-instruct"]
+    },
+    {
+      "id": "llama-3.1-70b",
+      "name": "Llama 3.1 70B",
+      "license": "llama-3-community",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 128000
+      },
+      "aliases": ["llama-3.1-70b-instruct"]
     }
   ]
 }

--- a/data/models/mistral-models.json
+++ b/data/models/mistral-models.json
@@ -87,6 +87,23 @@
         "total": 32768,
         "maxOutput": 4096
       }
+    },
+    {
+      "id": "codestral-2",
+      "name": "Codestral 2",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32768
+      }
     }
   ]
 }

--- a/data/models/openai-models.json
+++ b/data/models/openai-models.json
@@ -83,6 +83,27 @@
       ]
     },
     {
+      "id": "gpt-4o-mini",
+      "name": "GPT-4o Mini",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 16384
+      },
+      "aliases": [
+        "gpt-4o-mini-2024-07-18"
+      ]
+    },
+    {
       "id": "gpt-5-nano",
       "name": "GPT-5 Nano",
       "license": "proprietary",
@@ -282,6 +303,72 @@
         "embeddingType": "text",
         "normalized": true
       }
+    },
+    {
+      "id": "o1",
+      "name": "OpenAI o1",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "json-out",
+        "fn-out",
+        "reason"
+      ],
+      "context": {
+        "type": "token",
+        "total": 200000,
+        "maxOutput": 100000
+      },
+      "aliases": [
+        "o1-2024-12-17"
+      ]
+    },
+    {
+      "id": "o1-mini",
+      "name": "OpenAI o1 Mini",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "json-out",
+        "fn-out",
+        "reason"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 65536
+      },
+      "aliases": [
+        "o1-mini-2024-09-12"
+      ]
+    },
+    {
+      "id": "o1-preview",
+      "name": "OpenAI o1 Preview",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in",
+        "json-out",
+        "fn-out",
+        "reason"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32768
+      },
+      "aliases": [
+        "o1-preview-2024-09-12"
+      ]
     },
     {
       "id": "o4-mini",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aimodels",
-  "version": "0.5.2",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aimodels",
-      "version": "0.5.2",
+      "version": "0.6.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aimodels",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A collection of AI model specifications across different providers",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
This PR updates the model data files with the latest models released in 2024 and 2025.

**Changes:**
- **OpenAI**: Added `o1`, `o1-mini`, `o1-preview`, `gpt-4o-mini`.
- **Anthropic**: Added `claude-3-5-sonnet` (Oct 2024), `claude-3-5-haiku`, `claude-3-opus`.
- **Google**: Added `gemini-1.5-pro` (2M context), `gemini-1.5-flash` (1M context), `gemini-1.5-flash-8b`.
- **Meta**: Added `llama-3.1-405b`, `llama-3.1-70b`.
- **Mistral**: Added `codestral-2`.
- **DeepSeek**: Added `deepseek-v3.2`, `deepseek-r1-0528`.

**Validation:**
- Verified specs via Google Cloud Vertex AI documentation and OpenAI blog.
- Ran `npm run validate:data` (Passed).
- Ran `npm test` (Passed).
- Bumped `package.json` version to `0.6.1`.

---
*PR created automatically by Jules for task [7675832582308338150](https://jules.google.com/task/7675832582308338150) started by @mitkury*