### PR TITLE
data: Add latest models for Qwen, Mistral, Meta, and Google

### DIFF
--- a/data/models/google-models.json
+++ b/data/models/google-models.json
@@ -305,6 +305,54 @@
       }
     },
     {
+      "id": "gemma-2-27b-it",
+      "name": "Gemma 2 27B IT",
+      "license": "gemma",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 8192,
+        "maxOutput": 8192
+      }
+    },
+    {
+      "id": "gemma-2-9b-it",
+      "name": "Gemma 2 9B IT",
+      "license": "gemma",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 8192,
+        "maxOutput": 8192
+      }
+    },
+    {
+      "id": "gemma-2-2b-it",
+      "name": "Gemma 2 2B IT",
+      "license": "gemma",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 8192,
+        "maxOutput": 8192
+      }
+    },
+    {
       "id": "text-embedding-004",
       "name": "Text Embedding 004",
       "license": "proprietary",

--- a/data/models/meta-models.json
+++ b/data/models/meta-models.json
@@ -48,6 +48,28 @@
       }
     },
     {
+      "id": "llama-3.2-3b-instruct",
+      "name": "Llama 3.2 3B Instruct",
+      "license": "llama-3.2-community",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      }
+    },
+    {
+      "id": "llama-3.2-1b-instruct",
+      "name": "Llama 3.2 1B Instruct",
+      "license": "llama-3.2-community",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      }
+    },
+    {
       "id": "llama-3.2-11b-vision-preview",
       "name": "Llama 3.2 11B Vision",
       "license": "llama-3-community",

--- a/data/models/mistral-models.json
+++ b/data/models/mistral-models.json
@@ -10,6 +10,50 @@
       "aliases": ["mistral-medium-3", "mistral-medium-2025"]
     },
     {
+      "id": "mistral-large-2407",
+      "name": "Mistral Large 2",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 4096
+      }
+    },
+    {
+      "id": "pixtral-12b-2409",
+      "name": "Pixtral 12B",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "img-in", "json-out"],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 4096
+      }
+    },
+    {
+      "id": "ministral-8b-latest",
+      "name": "Ministral 8B",
+      "license": "proprietary",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out"],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 4096
+      }
+    },
+    {
+      "id": "open-mistral-nemo",
+      "name": "Mistral Nemo",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out"],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 4096
+      }
+    },
+    {
       "id": "mistral-large-2402",
       "name": "Mistral Large",
       "license": "proprietary",

--- a/data/models/qwen-models.json
+++ b/data/models/qwen-models.json
@@ -48,6 +48,102 @@
         "maxOutput": 8192
       },
       "aliases": ["qwen-3-7b", "qwen-3-7b-instruct-latest"]
+    },
+    {
+      "id": "qwen-2.5-72b-instruct",
+      "name": "Qwen 2.5 72B Instruct",
+      "license": "qwen",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["qwen-2.5-72b"]
+    },
+    {
+      "id": "qwen-2.5-32b-instruct",
+      "name": "Qwen 2.5 32B Instruct",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["qwen-2.5-32b"]
+    },
+    {
+      "id": "qwen-2.5-coder-32b-instruct",
+      "name": "Qwen 2.5 Coder 32B Instruct",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["qwen-2.5-coder-32b"]
+    },
+    {
+      "id": "qwen-2.5-14b-instruct",
+      "name": "Qwen 2.5 14B Instruct",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["qwen-2.5-14b"]
+    },
+    {
+      "id": "qwen-2.5-7b-instruct",
+      "name": "Qwen 2.5 7B Instruct",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["qwen-2.5-7b"]
+    },
+    {
+      "id": "qwen-2.5-3b-instruct",
+      "name": "Qwen 2.5 3B Instruct",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["qwen-2.5-3b"]
+    },
+    {
+      "id": "qwen-2.5-1.5b-instruct",
+      "name": "Qwen 2.5 1.5B Instruct",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["qwen-2.5-1.5b"]
+    },
+    {
+      "id": "qwen-2.5-0.5b-instruct",
+      "name": "Qwen 2.5 0.5B Instruct",
+      "license": "apache-2.0",
+      "capabilities": ["chat", "txt-in", "txt-out", "json-out", "fn-out"],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": ["qwen-2.5-0.5b"]
     }
   ]
 }


### PR DESCRIPTION
Added Qwen 2.5 Instruct/Coder models, Mistral Large 2/Pixtral/Ministral/Nemo, Llama 3.2 1B/3B, and Gemma 2 models. Verified JSON syntax and licenses.

---
*PR created automatically by Jules for task [4076475350200822970](https://jules.google.com/task/4076475350200822970) started by @mitkury*