### PR TITLE
Update Mistral and Qwen models for late 2025/early 2026

### DIFF
--- a/data/models/mistral-models.json
+++ b/data/models/mistral-models.json
@@ -2,6 +2,179 @@
   "creator": "mistral",
   "models": [
     {
+      "id": "mistral-large-3-25-12",
+      "name": "Mistral Large 3",
+      "license": "apache-2.0",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out",
+        "img-in"
+      ],
+      "context": {
+        "type": "token",
+        "total": 256000,
+        "maxOutput": 32000
+      },
+      "aliases": [
+        "mistral-large-3"
+      ]
+    },
+    {
+      "id": "mistral-medium-3-1-25-08",
+      "name": "Mistral Medium 3.1",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out",
+        "img-in"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32000
+      },
+      "aliases": [
+        "mistral-medium-3.1"
+      ]
+    },
+    {
+      "id": "mistral-small-3-2-25-06",
+      "name": "Mistral Small 3.2",
+      "license": "apache-2.0",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32000
+      },
+      "aliases": [
+        "mistral-small-3.2"
+      ]
+    },
+    {
+      "id": "ministral-3-14b-25-12",
+      "name": "Ministral 3 14B",
+      "license": "apache-2.0",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in"
+      ],
+      "context": {
+        "type": "token",
+        "total": 256000,
+        "maxOutput": 32000
+      }
+    },
+    {
+      "id": "ministral-3-8b-25-12",
+      "name": "Ministral 3 8B",
+      "license": "apache-2.0",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32000
+      }
+    },
+    {
+      "id": "magistral-medium-1-2-25-09",
+      "name": "Magistral Medium 1.2",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "reason"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32000
+      }
+    },
+    {
+      "id": "magistral-small-1-2-25-09",
+      "name": "Magistral Small 1.2",
+      "license": "apache-2.0",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "reason"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32000
+      }
+    },
+    {
+      "id": "codestral-25-08",
+      "name": "Codestral (August 2025)",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 256000,
+        "maxOutput": 32000
+      }
+    },
+    {
+      "id": "devstral-2-25-12",
+      "name": "Devstral 2",
+      "license": "apache-2.0",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32000
+      }
+    },
+    {
+      "id": "pixtral-large-24-11",
+      "name": "Pixtral Large",
+      "license": "proprietary",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "img-in"
+      ],
+      "context": {
+        "type": "token",
+        "total": 128000,
+        "maxOutput": 32000
+      }
+    },
+    {
       "id": "mistral-medium-3-2025-05-07",
       "name": "Mistral Medium 3",
       "license": "proprietary",

--- a/data/models/qwen-models.json
+++ b/data/models/qwen-models.json
@@ -2,6 +2,71 @@
   "creator": "qwen",
   "models": [
     {
+      "id": "qwen-3-coder-next",
+      "name": "Qwen 3 Coder Next",
+      "license": "apache-2.0",
+      "capabilities": [
+        "chat",
+        "txt-in",
+        "txt-out",
+        "json-out",
+        "fn-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 131072,
+        "maxOutput": 8192
+      },
+      "aliases": [
+        "qwen-3-coder-next-latest"
+      ]
+    },
+    {
+      "id": "qwen-image-2512",
+      "name": "Qwen Image 2512",
+      "license": "apache-2.0",
+      "capabilities": [
+        "txt-in",
+        "img-out"
+      ],
+      "context": {
+        "maxOutput": 1,
+        "sizes": [
+          "1024x1024"
+        ]
+      }
+    },
+    {
+      "id": "qwen-image-edit-2511",
+      "name": "Qwen Image Edit 2511",
+      "license": "apache-2.0",
+      "capabilities": [
+        "txt-in",
+        "img-in",
+        "img-out"
+      ],
+      "context": {
+        "maxOutput": 1,
+        "sizes": [
+          "1024x1024"
+        ]
+      }
+    },
+    {
+      "id": "qwen-3-asr-1.7b",
+      "name": "Qwen 3 ASR 1.7B",
+      "license": "apache-2.0",
+      "capabilities": [
+        "audio-in",
+        "txt-out"
+      ],
+      "context": {
+        "type": "token",
+        "total": 32000,
+        "maxOutput": 4096
+      }
+    },
+    {
       "id": "qwen-3-235b-instruct",
       "name": "Qwen 3 235B Instruct",
       "license": "apache-2.0",


### PR DESCRIPTION
Updated `mistral-models.json` with Mistral Large 3, Medium 3.1, Small 3.2, Ministral, Magistral, Codestral, Devstral, and Pixtral. Updated `qwen-models.json` with Qwen 3 Coder Next, Qwen Image, and Qwen 3 ASR.

---
*PR created automatically by Jules for task [8201462926840324965](https://jules.google.com/task/8201462926840324965) started by @mitkury*